### PR TITLE
Remove default 'script' Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
 language: rust
 notifications:
   webhooks: http://build.servo.org:54856/travis
-
-script:
-  - cargo build
-  - cargo test
-


### PR DESCRIPTION
These are the default options for Rust on Travis CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/devices/2)
<!-- Reviewable:end -->
