### PR TITLE
Add Bluetooth support for macOS via the BlurMac crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Servo Project Developers"]
 
 [features]
 default = ["bluetooth"]
-bluetooth = ["blurz", "blurdroid"]
+bluetooth = ["blurz", "blurdroid", "blurmac"]
 bluetooth-test = ["blurmock"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -13,6 +13,9 @@ blurz = { version = "0.2.1", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 blurdroid = { version = "0.1.2", optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+blurmac = { version = "0.0.1", optional = true }
 
 [dependencies]
 blurmock = { version = "0.1.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Underlying dependency crates:
 
 - Android platform: [blurdroid](https://crates.io/crates/blurdroid)
 - Linux platform: [blurz](https://crates.io/crates/blurz)
+- MacOS platform: [blurmac](https://crates.io/crates/blurmac)
 - `Fake` prefixed structures: [blurmock](https://crates.io/crates/blurmock)
 
 `Empty` prefixed structures are located in `empty.rs`.
@@ -18,7 +19,7 @@ Underlying dependency crates:
 ### Usage
 
 #### Without the *bluetooth-test* feature
-There are two supported platforms (Android, Linux), on other platforms we fall back to a default (`Empty` prefixed) implementation. Each enum (`BluetoothAdapter`, `BluetoothDevice`, etc.) will contain only one variant for each targeted platform. See the following `BluetoothAdapter` example:
+There are three supported platforms (Android, Linux, MacOS), on other platforms we fall back to a default (`Empty` prefixed) implementation. Each enum (`BluetoothAdapter`, `BluetoothDevice`, etc.) will contain only one variant for each targeted platform. See the following `BluetoothAdapter` example:
 
 Android:
 ```rust
@@ -30,6 +31,12 @@ Linux:
 ```rust
     pub enum BluetoothAdapter {
         Bluez(Arc<BluetoothAdapterBluez>),
+    }
+```
+MacOS:
+```rust
+    pub enum BluetoothAdapter {
+        Mac(Arc<BluetoothAdapterMac>),
     }
 ```
 
@@ -47,7 +54,7 @@ You will have a platform specific adapter, e.g. on android target, `BluetoothAda
         Ok(BluetoothAdapter::Android(Arc::new(blurdroid_adapter)))
     }
 ```
-On each platform you can call the same functions to reach the same GATT hierarchy elements. The following code can acces the same bluetooth device on both Android, and Linux platforms:
+On each platform you can call the same functions to reach the same GATT hierarchy elements. The following code can access the same bluetooth device on all supported platforms:
 
 ```rust
 use device::{BluetoothAdapter, BluetoothDevice};
@@ -62,7 +69,7 @@ fn main() {
 ```
 
 #### With the *bluetooth-test* feature
-The `bluetooth-test` feature is not a default feature, to use it, append `features = ["bluetooth-test"]`, to the `device` crate dependency in the project's `Cargo.toml`. 
+The `bluetooth-test` feature is not a default feature, to use it, append `features = ["bluetooth-test"]`, to the `device` crate dependency in the project's `Cargo.toml`.
 
 Each enum (`BluetoothAdapter`, `BluetoothDevice`, etc.) will contain one variant of the three possible default target, and a `Mock` variant, which wraps a `Fake` structure.
 
@@ -77,6 +84,13 @@ Linux:
 ```rust
     pub enum BluetoothAdapter {
         Bluez(Arc<BluetoothAdapterBluez>),
+        Mock(Arc<FakeBluetoothAdapter>),
+    }
+```
+Mac:
+```rust
+    pub enum BluetoothAdapter {
+        Mac(Arc<BluetoothAdapterMac>),
         Mock(Arc<FakeBluetoothAdapter>),
     }
 ```

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -6,47 +6,76 @@
 use blurz::bluetooth_adapter::BluetoothAdapter as BluetoothAdapterBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_adapter::Adapter as BluetoothAdapterAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+use blurmac::BluetoothAdapter as BluetoothAdapterMac;
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+              all(target_os = "android", feature = "bluetooth"),
+              all(target_os = "macos", feature = "bluetooth"))))]
 use empty::BluetoothAdapter as BluetoothAdapterEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_adapter::FakeBluetoothAdapter;
+
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_device::BluetoothDevice as BluetoothDeviceBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_device::Device as BluetoothDeviceAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+use blurmac::BluetoothDevice as BluetoothDeviceMac;
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+              all(target_os = "android", feature = "bluetooth"),
+              all(target_os = "macos", feature = "bluetooth"))))]
 use empty::BluetoothDevice as BluetoothDeviceEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_device::FakeBluetoothDevice;
+
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_characteristic::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_gatt_characteristic::Characteristic as BluetoothGATTCharacteristicAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+use blurmac::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicMac;
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+              all(target_os = "android", feature = "bluetooth"),
+              all(target_os = "macos", feature = "bluetooth"))))]
 use empty::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_characteristic::FakeBluetoothGATTCharacteristic;
+
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_descriptor::BluetoothGATTDescriptor as BluetoothGATTDescriptorBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_gatt_descriptor::Descriptor as BluetoothGATTDescriptorAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+use blurmac::BluetoothGATTDescriptor as BluetoothGATTDescriptorMac;
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+              all(target_os = "android", feature = "bluetooth"),
+              all(target_os = "macos", feature = "bluetooth"))))]
 use empty::BluetoothGATTDescriptor as BluetoothGATTDescriptorEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_descriptor::FakeBluetoothGATTDescriptor;
+
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_service::BluetoothGATTService as BluetoothGATTServiceBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_gatt_service::Service as BluetoothGATTServiceAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+use blurmac::BluetoothGATTService as BluetoothGATTServiceMac;
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+              all(target_os = "android", feature = "bluetooth"),
+              all(target_os = "macos", feature = "bluetooth"))))]
 use empty::BluetoothGATTService as BluetoothGATTServiceEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_service::FakeBluetoothGATTService;
+
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as BluetoothDiscoverySessionBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_discovery_session::DiscoverySession as BluetoothDiscoverySessionAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+use blurmac::BluetoothDiscoverySession as BluetoothDiscoverySessionMac;
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+              all(target_os = "android", feature = "bluetooth"),
+              all(target_os = "macos", feature = "bluetooth"))))]
 use empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_discovery_session::FakeBluetoothDiscoverySession;
@@ -66,7 +95,11 @@ pub enum BluetoothAdapter {
     Bluez(Arc<BluetoothAdapterBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
     Android(Arc<BluetoothAdapterAndroid>),
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    Mac(Arc<BluetoothAdapterMac>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                  all(target_os = "android", feature = "bluetooth"),
+                  all(target_os = "macos", feature = "bluetooth"))))]
     Empty(Arc<BluetoothAdapterEmpty>),
     #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothAdapter>),
@@ -78,7 +111,11 @@ pub enum BluetoothDiscoverySession {
     Bluez(Arc<BluetoothDiscoverySessionBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
     Android(Arc<BluetoothDiscoverySessionAndroid>),
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    Mac(Arc<BluetoothDiscoverySessionMac>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                  all(target_os = "android", feature = "bluetooth"),
+                  all(target_os = "macos", feature = "bluetooth"))))]
     Empty(Arc<BluetoothDiscoverySessionEmpty>),
     #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothDiscoverySession>),
@@ -90,7 +127,11 @@ pub enum BluetoothDevice {
     Bluez(Arc<BluetoothDeviceBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
     Android(Arc<BluetoothDeviceAndroid>),
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    Mac(Arc<BluetoothDeviceMac>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                  all(target_os = "android", feature = "bluetooth"),
+                  all(target_os = "macos", feature = "bluetooth"))))]
     Empty(Arc<BluetoothDeviceEmpty>),
     #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothDevice>),
@@ -102,7 +143,11 @@ pub enum BluetoothGATTService {
     Bluez(Arc<BluetoothGATTServiceBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
     Android(Arc<BluetoothGATTServiceAndroid>),
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    Mac(Arc<BluetoothGATTServiceMac>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                  all(target_os = "android", feature = "bluetooth"),
+                  all(target_os = "macos", feature = "bluetooth"))))]
     Empty(Arc<BluetoothGATTServiceEmpty>),
     #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothGATTService>),
@@ -114,7 +159,11 @@ pub enum BluetoothGATTCharacteristic {
     Bluez(Arc<BluetoothGATTCharacteristicBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
     Android(Arc<BluetoothGATTCharacteristicAndroid>),
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    Mac(Arc<BluetoothGATTCharacteristicMac>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                  all(target_os = "android", feature = "bluetooth"),
+                  all(target_os = "macos", feature = "bluetooth"))))]
     Empty(Arc<BluetoothGATTCharacteristicEmpty>),
     #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothGATTCharacteristic>),
@@ -126,7 +175,11 @@ pub enum BluetoothGATTDescriptor {
     Bluez(Arc<BluetoothGATTDescriptorBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
     Android(Arc<BluetoothGATTDescriptorAndroid>),
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    Mac(Arc<BluetoothGATTDescriptorMac>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                  all(target_os = "android", feature = "bluetooth"),
+                  all(target_os = "macos", feature = "bluetooth"))))]
     Empty(Arc<BluetoothGATTDescriptorEmpty>),
     #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothGATTDescriptor>),
@@ -139,7 +192,11 @@ macro_rules! get_inner_and_call(
             &$enum_type::Bluez(ref bluez) => bluez.$function_name(),
             #[cfg(all(target_os = "android", feature = "bluetooth"))]
             &$enum_type::Android(ref android) => android.$function_name(),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            &$enum_type::Mac(ref mac) => mac.$function_name(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
             &$enum_type::Empty(ref empty) => empty.$function_name(),
             #[cfg(feature = "bluetooth-test")]
             &$enum_type::Mock(ref fake) => fake.$function_name(),
@@ -152,7 +209,11 @@ macro_rules! get_inner_and_call(
             &$enum_type::Bluez(ref bluez) => bluez.$function_name($value),
             #[cfg(all(target_os = "android", feature = "bluetooth"))]
             &$enum_type::Android(ref android) => android.$function_name($value),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            &$enum_type::Mac(ref mac) => mac.$function_name($value),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
             &$enum_type::Empty(ref empty) => empty.$function_name($value),
             #[cfg(feature = "bluetooth-test")]
             &$enum_type::Mock(ref fake) => fake.$function_name($value),
@@ -190,7 +251,15 @@ impl BluetoothAdapter {
         Ok(BluetoothAdapter::Android(Arc::new(blurdroid_adapter)))
     }
 
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
+        let mac_adapter = try!(BluetoothAdapterMac::init());
+        Ok(BluetoothAdapter::Mac(Arc::new(mac_adapter)))
+    }
+
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                  all(target_os = "android", feature = "bluetooth"),
+                  all(target_os = "macos", feature = "bluetooth"))))]
     pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
         let adapter = try!(BluetoothAdapterEmpty::init());
         Ok(BluetoothAdapter::Empty(Arc::new(adapter)))
@@ -403,7 +472,14 @@ impl BluetoothDiscoverySession {
                 let blurdroid_session = try!(BluetoothDiscoverySessionAndroid::create_session(android_adapter));
                 Ok(BluetoothDiscoverySession::Android(Arc::new(blurdroid_session)))
             },
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            BluetoothAdapter::Mac(mac_adapter) => {
+                let mac_session = try!(BluetoothDiscoverySessionMac::create_session(mac_adapter));
+                Ok(BluetoothDiscoverySession::Mac(Arc::new(mac_session)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
             BluetoothAdapter::Empty(adapter) => {
                 let empty_session = try!(BluetoothDiscoverySessionEmpty::create_session(adapter));
                 Ok(BluetoothDiscoverySession::Empty(Arc::new(empty_session)))
@@ -437,7 +513,13 @@ impl BluetoothDevice {
             BluetoothAdapter::Android(android_adapter) => {
                 BluetoothDevice::Android(Arc::new(BluetoothDeviceAndroid::new(android_adapter, device)))
             },
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            BluetoothAdapter::Mac(mac_adapter) => {
+                BluetoothDevice::Mac(Arc::new(BluetoothDeviceMac::new(mac_adapter, device)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
             BluetoothAdapter::Empty(_adapter) => {
                 BluetoothDevice::Empty(Arc::new(BluetoothDeviceEmpty::new(device)))
             },
@@ -692,7 +774,13 @@ impl BluetoothGATTService {
             BluetoothDevice::Android(android_device) => {
                 BluetoothGATTService::Android(Arc::new(BluetoothGATTServiceAndroid::new(android_device, service)))
             },
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            BluetoothDevice::Mac(mac_device) => {
+                BluetoothGATTService::Mac(Arc::new(BluetoothGATTServiceMac::new(mac_device, service)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
             BluetoothDevice::Empty(_device) => {
                 BluetoothGATTService::Empty(Arc::new(BluetoothGATTServiceEmpty::new(service)))
             },
@@ -771,7 +859,13 @@ impl BluetoothGATTCharacteristic {
                 BluetoothGATTCharacteristic::Android(
                     Arc::new(BluetoothGATTCharacteristicAndroid::new(android_service, characteristic)))
             },
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            BluetoothGATTService::Mac(mac_service) => {
+                BluetoothGATTCharacteristic::Mac(Arc::new(BluetoothGATTCharacteristicMac::new(mac_service, characteristic)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
             BluetoothGATTService::Empty(_service) => {
                 BluetoothGATTCharacteristic::Empty(Arc::new(BluetoothGATTCharacteristicEmpty::new(characteristic)))
             },
@@ -882,7 +976,13 @@ impl BluetoothGATTDescriptor {
                 BluetoothGATTDescriptor::Android(
                     Arc::new(BluetoothGATTDescriptorAndroid::new(android_characteristic, descriptor)))
             },
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            BluetoothGATTCharacteristic::Mac(_mac_characteristic) => {
+                BluetoothGATTDescriptor::Mac(Arc::new(BluetoothGATTDescriptorMac::new(descriptor)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
             BluetoothGATTCharacteristic::Empty(_characteristic) => {
                 BluetoothGATTDescriptor::Empty(Arc::new(BluetoothGATTDescriptorEmpty::new(descriptor)))
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,13 @@
 extern crate blurz;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 extern crate blurdroid;
+#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+extern crate blurmac;
 #[cfg(feature = "bluetooth-test")]
 extern crate blurmock;
 
 pub mod bluetooth;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+              all(target_os = "android", feature = "bluetooth"),
+              all(target_os = "macos", feature = "bluetooth"))))]
 mod empty;


### PR DESCRIPTION
Until now, BT was supported on Linux and Android only. There is a new crate, BlurMac, which wraps the Core Bluetooth framework of macOS. With this commit and the BlurMac crate, macOS can become the third supported platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/devices/20)
<!-- Reviewable:end -->
