### PR TITLE
Make buetooth opt-in rather than opt-out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 authors = ["The Servo Project Developers"]
 
 [features]
-default = ["bluetooth"]
 bluetooth = ["blurz", "blurdroid", "blurmac"]
 bluetooth-test = ["blurmock"]
 


### PR DESCRIPTION
This fixes the problem of the magicleap build failing due to trying to build blurdroid.