### PR TITLE
Upgrade to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "device"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+edition = "2018"
 
 [features]
 bluetooth = ["blurz", "blurdroid", "blurmac"]

--- a/blurmac/src/adapter.rs
+++ b/blurmac/src/adapter.rs
@@ -26,7 +26,7 @@ unsafe impl Send for BluetoothAdapter {}
 unsafe impl Sync for BluetoothAdapter {}
 
 impl BluetoothAdapter {
-    pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
+    pub fn init() -> Result<BluetoothAdapter, Box<dyn Error>> {
         trace!("BluetoothAdapter::init");
         let delegate = bm::delegate();
         let manager = cb::centralmanager(delegate);
@@ -45,28 +45,28 @@ impl BluetoothAdapter {
         self.get_address().unwrap()
     }
 
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothAdapter::get_name");
         let controller = io::bluetoothhostcontroller_defaultcontroller();
         let name = io::bluetoothhostcontroller_nameasstring(controller);
         Ok(nsx::string_to_string(name))
     }
 
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothAdapter::get_address");
         let controller = io::bluetoothhostcontroller_defaultcontroller();
         let address = io::bluetoothhostcontroller_addressasstring(controller);
         Ok(nsx::string_to_string(address))
     }
 
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
         trace!("BluetoothAdapter::get_class");
         let controller = io::bluetoothhostcontroller_defaultcontroller();
         let device_class = io::bluetoothhostcontroller_classofdevice(controller);
         Ok(device_class)
     }
 
-    pub fn is_powered(&self) -> Result<bool, Box<Error>> {
+    pub fn is_powered(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothAdapter::is_powered");
         // NOTE: might be also available through
         // [[IOBluetoothHostController defaultController] powerState], but that's readonly, so keep
@@ -74,26 +74,26 @@ impl BluetoothAdapter {
         Ok(io::bluetoothpreferencegetcontrollerpowerstate() == 1)
     }
 
-    pub fn set_powered(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_powered(&self, value: bool) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothAdapter::set_powered");
         io::bluetoothpreferencesetcontrollerpowerstate(value as c_int);
         // TODO: wait for change to happen? whether it really happened?
         Ok(())
     }
 
-    pub fn is_discoverable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_discoverable(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothAdapter::is_discoverable");
         Ok(io::bluetoothpreferencegetdiscoverablestate() == 1)
     }
 
-    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<Error>> {
+    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothAdapter::set_discoverable");
         io::bluetoothpreferencesetdiscoverablestate(value as c_int);
         // TODO: wait for change to happen? whether it really happened?
         Ok(())
     }
 
-    pub fn get_device_list(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_device_list(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothAdapter::get_device_list");
         let mut v = vec!();
         let peripherals = bm::delegate_peripherals(self.delegate);
@@ -106,7 +106,7 @@ impl BluetoothAdapter {
 
     // Was in BluetoothDiscoverySession
 
-    fn start_discovery(&self) -> Result<(), Box<Error>> {
+    fn start_discovery(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothAdapter::start_discovery");
         let options = ns::mutabledictionary();
         // NOTE: If duplicates are not allowed then a peripheral will not show up again once
@@ -116,7 +116,7 @@ impl BluetoothAdapter {
         Ok(())
     }
 
-    fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    fn stop_discovery(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothAdapter::stop_discovery");
         cb::centralmanager_stopscan(self.manager);
         Ok(())
@@ -124,77 +124,77 @@ impl BluetoothAdapter {
 
     // Not supported
 
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_alias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_alias(&self, _value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, _value: String) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothAdapter::set_alias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_pairable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_pairable(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothAdapter::is_pairable not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_pairable(&self, _value: bool) -> Result<(), Box<Error>> {
+    pub fn set_pairable(&self, _value: bool) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothAdapter::set_pairable not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
+    pub fn get_pairable_timeout(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_pairable_timeout not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_pairable_timeout(&self, _value: u32) -> Result<(), Box<Error>> {
+    pub fn set_pairable_timeout(&self, _value: u32) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothAdapter::set_pairable_timeout not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
+    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_discoverable_timeout not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_discoverable_timeout(&self, _value: u32) -> Result<(), Box<Error>> {
+    pub fn set_discoverable_timeout(&self, _value: u32) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothAdapter::set_discoverable_timeout not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_discovering(&self) -> Result<bool, Box<Error>> {
+    pub fn is_discovering(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothAdapter::is_discovering not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_uuids not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_vendor_id_source not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_vendor_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_product_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothAdapter::get_device_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
         warn!("BluetoothAdapter::get_modalias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }

--- a/blurmac/src/delegate.rs
+++ b/blurmac/src/delegate.rs
@@ -6,7 +6,7 @@
 // according to those terms.
 
 use std::error::Error;
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Protocol, Sel};
@@ -24,7 +24,7 @@ pub mod bm {
 
     fn delegate_class() -> &'static Class {
         trace!("delegate_class");
-        static REGISTER_DELEGATE_CLASS: Once = ONCE_INIT;
+        static REGISTER_DELEGATE_CLASS: Once = Once::new();
 
         REGISTER_DELEGATE_CLASS.call_once(|| {
             let mut decl = ClassDecl::new("BlurMacDelegate", Class::get("NSObject").unwrap()).unwrap();
@@ -246,7 +246,7 @@ pub mod bm {
 pub mod bmx {
     use super::*;
 
-    pub fn peripheraldata(delegate: *mut Object, peripheral: *mut Object) -> Result<*mut Object, Box<Error>> {
+    pub fn peripheraldata(delegate: *mut Object, peripheral: *mut Object) -> Result<*mut Object, Box<dyn Error>> {
         let peripherals = bm::delegate_peripherals(delegate);
         let data = ns::dictionary_objectforkey(peripherals, ns::uuid_uuidstring(cb::peer_identifier(peripheral)));
         if data == nil {
@@ -256,7 +256,7 @@ pub mod bmx {
         Ok(data)
     }
 
-    pub fn peripheralevents(delegate: *mut Object, peripheral: *mut Object) -> Result<*mut Object, Box<Error>> {
+    pub fn peripheralevents(delegate: *mut Object, peripheral: *mut Object) -> Result<*mut Object, Box<dyn Error>> {
         let data = peripheraldata(delegate, peripheral)?;
         Ok(ns::dictionary_objectforkey(data, nsx::string_from_str(bm::PERIPHERALDATA_EVENTSKEY)))
     }

--- a/blurmac/src/device.rs
+++ b/blurmac/src/device.rs
@@ -57,7 +57,7 @@ impl BluetoothDevice {
         self.get_address().unwrap_or(String::new())
     }
 
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothDevice::get_address");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -69,7 +69,7 @@ impl BluetoothDevice {
         Ok(uuid_string)
     }
 
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothDevice::get_name");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -81,7 +81,7 @@ impl BluetoothDevice {
         Ok(name)
     }
 
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothDevice::get_uuids");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -100,7 +100,7 @@ impl BluetoothDevice {
 
     }
 
-    pub fn connect(&self) -> Result<(), Box<Error>> {
+    pub fn connect(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothDevice::connect");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -110,7 +110,7 @@ impl BluetoothDevice {
         Ok(())
     }
 
-    pub fn disconnect(&self) -> Result<(), Box<Error>> {
+    pub fn disconnect(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothDevice::disconnect");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -120,7 +120,7 @@ impl BluetoothDevice {
         Ok(())
     }
 
-    pub fn is_connected(&self) -> Result<bool, Box<Error>> {
+    pub fn is_connected(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothDevice::is_connected");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -131,7 +131,7 @@ impl BluetoothDevice {
         Ok(state == cb::PERIPHERALSTATE_CONNECTED)
     }
 
-    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothDevice::get_gatt_services");
         if self.peripheral == nil {
             return Err(Box::from(NO_PERIPHERAL_FOUND));
@@ -153,113 +153,113 @@ impl BluetoothDevice {
 
     // Not supported
 
-    pub fn get_rssi(&self) -> Result<i16, Box<Error>> {
+    pub fn get_rssi(&self) -> Result<i16, Box<dyn Error>> {
         warn!("BluetoothDevice::get_rssi not supported by BlurMac");
         // TODO: Now available from peripheral data in BluetoothAdapter.
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
+    pub fn get_tx_power(&self) -> Result<i16, Box<dyn Error>> {
         warn!("BluetoothDevice::get_tx_power not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<Error>> {
+    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<dyn Error>> {
         warn!("BluetoothDevice::get_manufacturer_data not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<Error>> {
+    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<dyn Error>> {
         warn!("BluetoothDevice::get_service_data not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_icon(&self) -> Result<String, Box<Error>> {
+    pub fn get_icon(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothDevice::get_icon not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothDevice::get_class not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_appearance(&self) -> Result<u16, Box<Error>> {
+    pub fn get_appearance(&self) -> Result<u16, Box<dyn Error>> {
         warn!("BluetoothDevice::get_appearance not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_paired(&self) -> Result<bool, Box<Error>> {
+    pub fn is_paired(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothDevice::is_paired not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_trusted(&self) -> Result<bool, Box<Error>> {
+    pub fn is_trusted(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothDevice::is_trusted not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_blocked(&self) -> Result<bool, Box<Error>> {
+    pub fn is_blocked(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothDevice::is_blocked not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothDevice::get_alias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_alias(&self, _value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, _value: String) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::set_alias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
+    pub fn is_legacy_pairing(&self) -> Result<bool, Box<dyn Error>> {
         warn!("BluetoothDevice::is_legacy_pairing not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
         warn!("BluetoothDevice::get_vendor_id_source not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothDevice::get_vendor_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothDevice::get_product_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
         warn!("BluetoothDevice::get_device_id not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
         warn!("BluetoothDevice::get_modalias not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn connect_profile(&self, _uuid: String) -> Result<(), Box<Error>> {
+    pub fn connect_profile(&self, _uuid: String) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::connect_profile not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn disconnect_profile(&self, _uuid: String) -> Result<(), Box<Error>> {
+    pub fn disconnect_profile(&self, _uuid: String) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::disconnect_profile not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn pair(&self) -> Result<(), Box<Error>> {
+    pub fn pair(&self) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::pair not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
+    pub fn cancel_pairing(&self) -> Result<(), Box<dyn Error>> {
         warn!("BluetoothDevice::cancel_pairing not supported by BlurMac");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }

--- a/blurmac/src/discovery_session.rs
+++ b/blurmac/src/discovery_session.rs
@@ -17,20 +17,20 @@ pub struct BluetoothDiscoverySession {
 }
 
 impl BluetoothDiscoverySession {
-    pub fn create_session(_adapter: Arc<BluetoothAdapter>) -> Result<BluetoothDiscoverySession, Box<Error>> {
+    pub fn create_session(_adapter: Arc<BluetoothAdapter>) -> Result<BluetoothDiscoverySession, Box<dyn Error>> {
         trace!("BluetoothDiscoverySession::create_session");
         Ok(BluetoothDiscoverySession {
             // adapter: adapter.clone()
         })
     }
 
-    pub fn start_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn start_discovery(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothDiscoverySession::start_discovery");
         // NOTE: discovery is started by BluetoothAdapter::new to allow devices to pop up
         Ok(())
     }
 
-    pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn stop_discovery(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothDiscoverySession::stop_discovery");
         // NOTE: discovery is only stopped when BluetoothAdapter is dropped
         Ok(())

--- a/blurmac/src/gatt_characteristic.rs
+++ b/blurmac/src/gatt_characteristic.rs
@@ -57,7 +57,7 @@ impl BluetoothGATTCharacteristic {
         self.get_uuid().unwrap_or(String::new())
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::get_uuid");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -68,7 +68,7 @@ impl BluetoothGATTCharacteristic {
         Ok(uuid_string)
     }
 
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::get_value");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -86,7 +86,7 @@ impl BluetoothGATTCharacteristic {
         Ok(v)
     }
 
-    pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::read_value");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -106,7 +106,7 @@ impl BluetoothGATTCharacteristic {
         self.get_value()
     }
 
-    pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::write_value");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -126,7 +126,7 @@ impl BluetoothGATTCharacteristic {
         Ok(())
     }
 
-    pub fn is_notifying(&self) -> Result<bool, Box<Error>> {
+    pub fn is_notifying(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::is_notifying");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -137,7 +137,7 @@ impl BluetoothGATTCharacteristic {
         Ok(notifying != NO)
     }
 
-    pub fn start_notify(&self) -> Result<(), Box<Error>> {
+    pub fn start_notify(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::start_notify");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -147,7 +147,7 @@ impl BluetoothGATTCharacteristic {
         Ok(())
     }
 
-    pub fn stop_notify(&self) -> Result<(), Box<Error>> {
+    pub fn stop_notify(&self) -> Result<(), Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::stop_notify");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));
@@ -157,12 +157,12 @@ impl BluetoothGATTCharacteristic {
         Ok(())
     }
 
-    pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<dyn Error>> {
         warn!("BluetoothGATTCharacteristic::get_gatt_descriptors");
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothGATTCharacteristic::get_flags");
         if self.characteristic == nil {
             return Err(Box::from(NO_CHARACTERISTIC_FOUND));

--- a/blurmac/src/gatt_descriptor.rs
+++ b/blurmac/src/gatt_descriptor.rs
@@ -22,23 +22,23 @@ impl BluetoothGATTDescriptor {
         String::new()
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn write_value(&self, _values: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, _values: Vec<u8>) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 }

--- a/blurmac/src/gatt_service.rs
+++ b/blurmac/src/gatt_service.rs
@@ -58,7 +58,7 @@ impl BluetoothGATTService {
         self.get_uuid().unwrap_or(String::new())
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         trace!("BluetoothGATTService::get_uuid");
         if self.service == nil {
             return Err(Box::from(NO_SERVICE_FOUND));
@@ -69,7 +69,7 @@ impl BluetoothGATTService {
         Ok(uuid_string)
     }
 
-    pub fn is_primary(&self) -> Result<bool, Box<Error>> {
+    pub fn is_primary(&self) -> Result<bool, Box<dyn Error>> {
         trace!("BluetoothGATTService::is_primary");
         if self.service == nil {
             return Err(Box::from(NO_SERVICE_FOUND));
@@ -82,7 +82,7 @@ impl BluetoothGATTService {
         Ok(true)
     }
 
-    pub fn get_includes(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_includes(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothGATTService::get_includes");
         if self.service == nil {
             return Err(Box::from(NO_SERVICE_FOUND));
@@ -100,7 +100,7 @@ impl BluetoothGATTService {
         Ok(v)
     }
 
-    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<dyn Error>> {
         trace!("BluetoothGATTService::get_gatt_characteristics");
         if self.service == nil {
             return Err(Box::from(NO_SERVICE_FOUND));

--- a/blurmac/src/utils.rs
+++ b/blurmac/src/utils.rs
@@ -7,7 +7,7 @@
 
 use std::error::Error;
 use std::ffi::{CStr, CString};
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time;
 use std::thread;
 
@@ -32,7 +32,8 @@ pub mod nsx {
     }
 
     pub fn string_from_str(string: &str) -> *mut Object {
-        ns::string(CString::new(string).unwrap().as_ptr())
+        let cstring = CString::new(string).unwrap();
+        ns::string(cstring.as_ptr())
     }
 }
 
@@ -78,7 +79,7 @@ pub mod wait {
 
     pub type Timestamp = u64;
 
-    static TIMESTAMP: AtomicUsize = ATOMIC_USIZE_INIT;
+    static TIMESTAMP: AtomicUsize = AtomicUsize::new(0);
 
     pub fn get_timestamp() -> Timestamp {
         TIMESTAMP.fetch_add(1, Ordering::SeqCst) as u64
@@ -88,7 +89,7 @@ pub mod wait {
         ns::number_withunsignedlonglong(get_timestamp())
     }
 
-    pub fn wait_or_timeout<F>(mut f: F) -> Result<(), Box<Error>>
+    pub fn wait_or_timeout<F>(mut f: F) -> Result<(), Box<dyn Error>>
         where F: FnMut() -> bool {
 
         let now = time::Instant::now();

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -7,7 +7,7 @@ use blurmac::BluetoothAdapter as BluetoothAdapterMac;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
-use empty::EmptyAdapter as BluetoothAdapterEmpty;
+use super::empty::EmptyAdapter as BluetoothAdapterEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_adapter::FakeBluetoothAdapter;
 
@@ -20,7 +20,7 @@ use blurmac::BluetoothDiscoverySession as BluetoothDiscoverySessionMac;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
-use empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
+use super::empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_discovery_session::FakeBluetoothDiscoverySession;
 
@@ -33,715 +33,315 @@ use blurmac::BluetoothDevice as BluetoothDeviceMac;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
-use empty::BluetoothDevice as BluetoothDeviceEmpty;
+use super::empty::BluetoothDevice as BluetoothDeviceEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_device::FakeBluetoothDevice;
 
+use super::macros::get_inner_and_call;
 #[cfg(feature = "bluetooth-test")]
-const NOT_SUPPORTED_ON_REAL_ERROR: &'static str = "Error! Test functions are not supported on real devices!";
-#[cfg(feature = "bluetooth-test")]
-const NOT_SUPPORTED_ON_MOCK_ERROR: &'static str = "Error! The first parameter must be a mock structure!";
+use super::macros::get_inner_and_call_test_func;
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::error::Error;
-const NOT_SUPPORTED_ERROR: &'static str = "Error! Not supported platform!";
 
-use bluetooth::BluetoothDevice;
-use bluetooth::BluetoothDiscoverySession;
+use super::bluetooth::BluetoothDevice;
+use super::bluetooth::BluetoothDiscoverySession;
 
-pub trait BluetoothAdapter {
-    fn get_id(&self)-> String;
-   fn set_id(&self, id: String)-> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))
-     }
-    fn get_devices(&self)-> Result<Vec<BluetoothDevice>, Box<Error>>;
-    fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<Error>>;
-    fn create_mock_device(&self, device: String) -> Result<BluetoothDevice, Box<Error>> {
-         Err(Box::from(NOT_SUPPORTED_ERROR))   
-    }
-    fn get_address(&self) -> Result<String, Box<Error>>;
-    fn set_address(&self, address: String) -> Result<(), Box<Error>>{
-         Err(Box::from(NOT_SUPPORTED_ERROR))
-     }
-    fn get_name(&self)-> Result<String, Box<Error>>;
-    fn set_name(&self, name: String) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))
-    }
-    fn get_alias(&self) -> Result<String, Box<Error>>;
-    fn set_alias(&self, alias: String) -> Result<(), Box<Error>>{
-         Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn get_class(&self)-> Result<u32, Box<Error>>;
-    fn set_class(&self, class: u32) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn is_powered(&self)-> Result<bool, Box<Error>>;
-    fn set_powered(&self, powered: bool) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn is_present(&self) -> Result<bool, Box<Error>>{
-         Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn set_present(&self, present: bool) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn is_discoverable(&self) -> Result<bool, Box<Error>>;
-    fn set_discoverable(&self, discoverable: bool) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn is_pairable(&self)-> Result<bool, Box<Error>>;
-    fn set_pairable(&self, pairable: bool) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn get_pairable_timeout(&self) -> Result<u32, Box<Error>>;
-    fn set_pairable_timeout(&self, timeout: u32) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn get_discoverable_timeout(&self)-> Result<u32, Box<Error>>;
-    fn set_discoverable_timeout(&self, timeout: u32) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    } 
-    fn is_discovering(&self)-> Result<bool, Box<Error>>;
-    fn set_discovering(&self, discovering: bool) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    } 
-    fn set_can_start_discovery(&self, can_start_discovery: bool) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn set_can_stop_discovery(&self, can_stop_discovery: bool) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn create_discovery_session(&self)-> Result<BluetoothDiscoverySession, Box<Error>>;
-    fn get_uuids(&self)-> Result<Vec<String>, Box<Error>>;
-    fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    } 
-    fn get_vendor_id_source(&self)-> Result<String, Box<Error>>;
-    fn get_vendor_id(&self)-> Result<u32, Box<Error>>;
-    fn get_product_id(&self) -> Result<u32, Box<Error>> ;
-    fn get_device_id(&self) -> Result<u32, Box<Error>>;
-    fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>>;  
-    fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn get_ad_datas(&self) -> Result<Vec<String>, Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
-    fn set_ad_datas(&self, ad_datas: Vec<String>) -> Result<(), Box<Error>>{
-        Err(Box::from(NOT_SUPPORTED_ERROR))  
-    }
+#[derive(Clone, Debug)]
+pub enum BluetoothAdapter {
+    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+    Bluez(Arc<BluetoothAdapterBluez>),
+    #[cfg(all(target_os = "android", feature = "bluetooth"))]
+    Android(Arc<BluetoothAdapterAndroid>),
+    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    Mac(Arc<BluetoothAdapterMac>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                  all(target_os = "android", feature = "bluetooth"),
+                  all(target_os = "macos", feature = "bluetooth"))))]
+    Empty(Arc<BluetoothAdapterEmpty>),
+    #[cfg(feature = "bluetooth-test")]
+    Mock(Arc<FakeBluetoothAdapter>)
 }
 
-impl BluetoothAdapter{
+impl BluetoothAdapter {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    pub fn new() -> Result<Box<BluetoothAdapter>, Box<Error>> {
-        let bluez_adapter = try!(BluetoothAdapterBluez::init());
-        Ok(Box::new(Bluez(Arc::new(bluez_adapter))))
+    pub fn new() -> Result<BluetoothAdapter, Box<dyn Error>> {
+        let bluez_adapter = BluetoothAdapterBluez::init()?;
+        Ok(Self::Bluez(Arc::new(bluez_adapter)))
     }
 
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    pub fn new() -> Result<Box<BluetoothAdapter>, Box<Error>> {
-        let blurdroid_adapter = try!(BluetoothAdapterAndroid::get_adapter());
-        Ok(Box::new(Android(Arc::new(blurdroid_adapter))))
+    pub fn new() -> Result<BluetoothAdapter, Box<dyn Error>> {
+        let blurdroid_adapter = BluetoothAdapterAndroid::get_adapter()?;
+        Ok(Self::Android(Arc::new(blurdroid_adapter)))
     }
 
     #[cfg(all(target_os = "macos", feature = "bluetooth"))]
-    pub fn new() -> Result<Box<BluetoothAdapter>, Box<Error>> {
-        let mac_adapter = try!(BluetoothAdapterMac::init());
-        Ok(Box::new(Mac(Arc::new(mac_adapter))))
+    pub fn new() -> Result<BluetoothAdapter, Box<dyn Error>> {
+        let mac_adapter = BluetoothAdapterMac::init()?;
+        Ok(Self::Mac(Arc::new(mac_adapter)))
     }
 
     #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
                   all(target_os = "android", feature = "bluetooth"),
                   all(target_os = "macos", feature = "bluetooth"))))]
-    pub fn new() -> Result<Box<BluetoothAdapter>, Box<Error>> {
-        let adapter = try!(BluetoothAdapterEmpty::init());
-        Ok(Box::new(Empty(Arc::new(adapter))))
+    pub fn new() -> Result<BluetoothAdapter, Box<dyn Error>> {
+        let adapter = BluetoothAdapterEmpty::init()?;
+        Ok(Self::Empty(Arc::new(adapter)))
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn new_mock() -> Result<Box<BluetoothAdapter>, Box<Error>> {
-        let fake_adapter = Mock(FakeBluetoothAdapter::new_empty());
-        Ok(Box::new(fake_adapter))
-    }
-}   
-
-#[derive(Clone, Debug)]
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
-struct Bluez(Arc<BluetoothAdapterBluez>);
-
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
-impl BluetoothAdapter for Bluez{
-
-    fn get_id(&self) -> String{
-        self.0.get_id()
-    } 
-
-    fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<Error>>{
-        let device_list = try!(self.0.get_device_list());
-        Ok(device_list.into_iter().map(|device|  BluetoothDevice::Bluez(Arc::new(BluetoothDeviceBluez::new(device)))).collect())
+    pub fn new_mock() -> Result<BluetoothAdapter, Box<dyn Error>> {
+        Ok(Self::Mock(FakeBluetoothAdapter::new_empty()))
     }
 
-    fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<Error>> {
-        let devices = try!(self.get_devices());
+    pub fn get_id(&self) -> String {
+        get_inner_and_call!(self, BluetoothAdapter, get_id)
+    }
+
+    pub fn get_devices(&self)-> Result<Vec<BluetoothDevice>, Box<dyn Error>> {
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            BluetoothAdapter::Bluez(inner) => {
+                let device_list = inner.get_device_list()?;
+                Ok(device_list.into_iter().map(|device| BluetoothDevice::Bluez(BluetoothDeviceBluez::new_empty(self.0.clone(), device))).collect())
+            }
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            BluetoothAdapter::Android(inner) =>  {
+                let device_list = inner.get_device_list()?;
+                Ok(device_list.into_iter().map(|device| BluetoothDevice::Android(BluetoothDeviceAndroid::new_empty(self.0.clone(), device))).collect())
+            }
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            BluetoothAdapter::Mac(inner) => {
+                let device_list = inner.get_device_list()?;
+                Ok(device_list.into_iter().map(|device|  BluetoothDevice::Mac(Arc::new(BluetoothDeviceMac::new(inner.clone(),device)))).collect())
+
+            }
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                        all(target_os = "android", feature = "bluetooth"),
+                        all(target_os = "macos", feature = "bluetooth"))))]
+            BluetoothAdapter::Empty(inner) => {
+                let device_list = inner.get_device_list()?;
+                Ok(device_list.into_iter().map(|device| BluetoothDevice::Empty(Arc::new(BluetoothDeviceEmpty::new(device)))).collect())
+            }
+            #[cfg(feature = "bluetooth-test")]
+            BluetoothAdapter::Mock(inner) => {
+                let device_list = inner.get_device_list()?;
+                Ok(device_list.into_iter().map(|device| BluetoothDevice::Mock(FakeBluetoothDevice::new_empty(inner.clone(), device))).collect())
+            }
+        }
+    }
+
+    pub fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<dyn Error>> {
+        let devices = self.get_devices()?;
         for device in devices {
-            if try!(device.get_address()) == address {
+            if device.get_address()? == address {
                 return Ok(Some(device));
             }
         }
         Ok(None)
     }
 
-    fn get_address(&self) -> Result<String, Box<Error>> {
-        self.0.get_address()
-    }
-
-    fn get_name(&self) -> Result<String, Box<Error>> {
-        self.0.get_name()
-    }
-
-    fn get_alias(&self) -> Result<String, Box<Error>> {
-        self.0.get_alias()
-    }
-
-    fn get_class(&self) -> Result<u32, Box<Error>> {
-        self.0.get_class()
-    }
-
-    fn is_powered(&self) -> Result<bool, Box<Error>> {
-        self.0.is_powered()
-    }
-
-    fn is_discoverable(&self) -> Result<bool, Box<Error>> {
-       self.0.is_discoverable()
-    }
-
-    fn is_pairable(&self) -> Result<bool, Box<Error>> {
-       self.0.is_pairable()
-    }
-
-    fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
-       self.0.get_pairable_timeout()
-    }
-
-    fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
-       self.0.get_discoverable_timeout()
-   }
-    fn is_discovering(&self) -> Result<bool, Box<Error>> {
-       self.0.is_discovering()
-    }
-
-    fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let bluez_session = try!(BluetoothDiscoverySessionBluez::create_session(self.get_id()));
-        Ok(BluetoothDiscoverySession::Bluez(Arc::new(bluez_session)))
-    }
-
-    fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-        self.0.get_uuids()
-    }
-
-    fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        self.0.get_vendor_id_source()
-    }
-
-    fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_vendor_id()
-    }
-
-    fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_product_id()
-    }
-
-    fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_device_id()
-    }
-
-    fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        self.0.get_modalias()
-    }
-    fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>>{
-        self.0.set_modalias(modalias)
-    }
-
-}   
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
-struct Android(Arc<BluetoothAdapterAndroid>);
-
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
-impl BluetoothAdapter for Android{
-
-    fn get_id(&self) -> String{
-        self.0.get_id()
-    }
-  
-    fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<Error>>{
-        let device_list = try!(self.0.get_device_list());
-        Ok(device_list.into_iter().map(|device|  BluetoothDevice::Android(Arc::new(BluetoothDeviceAndroid::new(self.0.clone(), device)))).collect())
-    }
-
-    fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<Error>> {
-        let devices = try!(self.get_devices());
-        for device in devices {
-            if try!(device.get_address()) == address {
-                return Ok(Some(device));
+    pub fn create_mock_device(&self, _device: String) -> Result<BluetoothDevice, Box<dyn Error>> {
+        match self {
+            #[cfg(feature = "bluetooth-test")]
+            BluetoothAdapter::Mock(inner) => {
+                Ok(BluetoothDevice::Mock(FakeBluetoothDevice::new_empty(inner.clone(), _device)))
+            }
+            _ => {
+                Err(Box::from("Error! Test functions are not supported on real devices!"))
             }
         }
-        Ok(None)
     }
 
-   fn get_address(&self) -> Result<String, Box<Error>> {
-        self.0.get_address()
-    }
-
-    fn get_name(&self) -> Result<String, Box<Error>> {
-        self.0.get_name()
-    }
- 
-
-    fn get_alias(&self) -> Result<String, Box<Error>> {
-        self.0.get_alias()
-    }
-    fn get_class(&self) -> Result<u32, Box<Error>> {
-        self.0.get_class()
-    }
-
-    fn is_powered(&self) -> Result<bool, Box<Error>> {
-        self.0.is_powered()
-    }
-
-    fn is_discoverable(&self) -> Result<bool, Box<Error>> {
-       self.0.is_discoverable()
-    }
-
-    fn is_pairable(&self) -> Result<bool, Box<Error>> {
-       self.0.is_pairable()
-    }
-
-    fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
-       self.0.get_pairable_timeout()
-    }
-
-    fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
-       self.0.get_discoverable_timeout()
-    }
-    fn is_discovering(&self) -> Result<bool, Box<Error>> {
-       self.0.is_discovering()
-    }
-
-    fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let blurdroid_session = try!(BluetoothDiscoverySessionAndroid::create_session(self.0.clone()));
-        Ok(BluetoothDiscoverySession::Android(Arc::new(blurdroid_session)))
-    }
-
-    
-    fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-        self.0.get_uuids()
-    }
- 
-    fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        self.0.get_vendor_id_source()
-    }
-
-    fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_vendor_id()
-    }
-
-    fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_product_id()
-    }
-
-    fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_device_id()
-    }
-
-    fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        self.0.get_modalias()
-    }
-}
-
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
-struct Mac(Arc<BluetoothAdapterMac>);
-
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
-impl BluetoothAdapter for Mac{
-
-    fn get_id(&self) -> String{
-        self.0.get_id()
- 
-    }
-    fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<Error>>{
-        let device_list = try!(self.0.get_device_list());
-        Ok(device_list.into_iter().map(|device| BluetoothDevice::Mac(Arc::new(BluetoothDeviceMac::new(self.0.clone(),device)))).collect())
-    }
-    
-
-    fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<Error>> {
-        let devices = try!(self.get_devices());
-        for device in devices {
-            if try!(device.get_address()) == address {
-                return Ok(Some(device));
+    pub fn create_discovery_session(&self)-> Result<BluetoothDiscoverySession, Box<dyn Error>> {
+        let discovery_session = match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            BluetoothAdapter::Bluez(inner) => {
+                BluetoothDiscoverySession::Bluez(Arc::new(BluetoothDiscoverySessionBluez::create_session(inner.get_id())?));
             }
-        }
-        Ok(None)
-    }
-
-    fn get_address(&self) -> Result<String, Box<Error>> {
-        self.0.get_address()
-    }
-
-    fn get_name(&self) -> Result<String, Box<Error>> {
-        self.0.get_name()
-    }
-    fn get_alias(&self) -> Result<String, Box<Error>> {
-        self.0.get_alias()
-    }
-    fn get_class(&self) -> Result<u32, Box<Error>> {
-        self.0.get_class()
-    }
-
-    fn is_powered(&self) -> Result<bool, Box<Error>> {
-        self.0.is_powered()
-    }
-
-    fn is_discoverable(&self) -> Result<bool, Box<Error>> {
-       self.0.is_discoverable()
-    }
-
-    fn is_pairable(&self) -> Result<bool, Box<Error>> {
-       self.0.is_pairable()
-    }
-
-    fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
-       self.0.get_pairable_timeout()
-    }
-    fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
-       self.0.get_discoverable_timeout()
-    }
-
-    fn is_discovering(&self) -> Result<bool, Box<Error>> {
-       self.0.is_discovering()
-    }
-   
-    fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let mac_session = BluetoothDiscoverySessionMac{};
-        Ok(BluetoothDiscoverySession::Mac(Arc::new(mac_session)))
-    }
-    fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-        self.0.get_uuids()
-    }
-
-    fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        self.0.get_vendor_id_source()
-    }
-
-    fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_vendor_id()
-    }
-
-    fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_product_id()
-    }
-
-    fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_device_id()
-    }
-
-    fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        self.0.get_modalias()
-    }   
-} 
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-              all(target_os = "android", feature = "bluetooth"),
-              all(target_os = "macos", feature = "bluetooth"))))]
-struct Empty(Arc<BluetoothAdapterEmpty>);
-
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-              all(target_os = "android", feature = "bluetooth"),
-              all(target_os = "macos", feature = "bluetooth"))))]
-impl BluetoothAdapter for Empty{
-    
-    fn get_id(&self) -> String{
-        self.0.get_id()
-    }
-
-
-    fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<Error>>{
-        let device_list = try!(self.0.get_device_list());
-        Ok(device_list.into_iter().map(|device| BluetoothDevice::Empty(Arc::new(BluetoothDeviceEmpty::new(device)))).collect())
-    }
-
-    fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<Error>> {
-        let devices = try!(self.get_devices());
-        for device in devices {
-            if try!(device.get_address()) == address {
-                return Ok(Some(device));
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            BluetoothAdapter::Android(inner) => {
+                BluetoothDiscoverySession::Android(Arc::new(BluetoothDiscoverySessionAndroid::create_session(inner.clone())?))
             }
-        }
-        Ok(None)
-    }
-
-    fn get_address(&self) -> Result<String, Box<Error>> {
-        self.0.get_address()
-    }
-
-    fn get_name(&self) -> Result<String, Box<Error>> {
-        self.0.get_name()
-    }
-
-    fn get_alias(&self) -> Result<String, Box<Error>> {
-        self.0.get_alias()
-    }
-
-
-    fn get_class(&self) -> Result<u32, Box<Error>> {
-        self.0.get_class()
-    }
-    
-
-    fn is_powered(&self) -> Result<bool, Box<Error>> {
-        self.0.is_powered()
-    }
-
-    
-    fn is_discoverable(&self) -> Result<bool, Box<Error>> {
-       self.0.is_discoverable()
-    }
-
-    fn set_discoverable(&self, discoverable: bool) -> Result<(), Box<Error>>{
-        self.0.set_discoverable(discoverable)
-    }
-
-    fn is_pairable(&self) -> Result<bool, Box<Error>> {
-       self.0.is_pairable()
-    }
-    
-
-
-    fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
-       self.0.get_pairable_timeout()
-    }
-
-    
-    fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
-       self.0.get_discoverable_timeout()
-    }
-    fn set_discoverable_timeout(&self, timeout: u32) -> Result<(), Box<Error>>{
-       self.0.set_discoverable_timeout(timeout)
-    }
-
-    fn is_discovering(&self) -> Result<bool, Box<Error>> {
-       self.0.is_discovering()
-    }
-    
-    fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let empty_session = BluetoothDiscoverySessionEmpty{};
-        Ok(BluetoothDiscoverySession::Empty(Arc::new(empty_session)))
-                       
-    }
-
-    fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-        self.0.get_uuids()
-    }
-    
-    fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        self.0.get_vendor_id_source()
-    }
-
-    fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_vendor_id()
-    }
-
-    fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_product_id()
-    }
-
-    fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_device_id()
-    }
-
-    fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        self.0.get_modalias()
-    }
-
-}
-
-
-#[cfg(feature = "bluetooth-test")]
-struct Mock(Arc<FakeBluetoothAdapter>);
-
-#[cfg(feature = "bluetooth-test")]
-impl BluetoothAdapter for Mock{
-
-    fn get_id(&self) -> String {
-        self.0.get_id()
-    }
-
-    fn set_id(&self, id: String) -> Result<(), Box<Error>> {
-       Ok(self.0.set_id(id))
-    }
-
-    fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<Error>> {
-        let device_list = try!(self.0.get_device_list());
-        Ok(device_list.into_iter().map(|device| BluetoothDevice::Mock(FakeBluetoothDevice::new_empty(self.0.clone(), device))).collect())
-    }
-
-    fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<Error>> {
-        let devices = try!(self.get_devices());
-        for device in devices {
-            if try!(device.get_address()) == address {
-                return Ok(Some(device));
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            BluetoothAdapter::Mac(_) => {
+                BluetoothDiscoverySession::Mac(Arc::new(BluetoothDiscoverySessionMac{}))
             }
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                        all(target_os = "android", feature = "bluetooth"),
+                        all(target_os = "macos", feature = "bluetooth"))))]
+            BluetoothAdapter::Empty(_) => {
+                BluetoothDiscoverySession::Empty(Arc::new(BluetoothDiscoverySessionEmpty{}))
+            }
+            #[cfg(feature = "bluetooth-test")]
+            BluetoothAdapter::Mock(inner) => {
+                BluetoothDiscoverySession::Mock(Arc::new(FakeBluetoothDiscoverySession::create_session(inner.clone())?))
+            }
+        };
+        Ok(discovery_session)
+    }
+
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_address)
+    }
+
+    pub fn get_name(&self)-> Result<String, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_name)
+    }
+
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_alias)
+    }
+
+    pub fn get_class(&self)-> Result<u32, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_class)
+    }
+
+    pub fn is_powered(&self)-> Result<bool, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, is_powered)
+    }
+
+    pub fn is_discoverable(&self) -> Result<bool, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, is_discoverable)
+    }
+
+    pub fn is_pairable(&self)-> Result<bool, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, is_pairable)
+    }
+
+    pub fn get_pairable_timeout(&self) -> Result<u32, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_pairable_timeout)
+    }
+
+    pub fn get_discoverable_timeout(&self)-> Result<u32, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_discoverable_timeout)
+    }
+
+    pub fn is_discovering(&self)-> Result<bool, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, is_discovering)
+    }
+
+    pub fn get_uuids(&self)-> Result<Vec<String>, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_uuids)
+    }
+
+    pub fn get_vendor_id_source(&self)-> Result<String, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_vendor_id_source)
+    }
+
+    pub fn get_vendor_id(&self)-> Result<u32, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_vendor_id)
+    }
+
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_product_id)
+    }
+
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_device_id)
+    }
+
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
+        get_inner_and_call!(self, BluetoothAdapter, get_modalias)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_id(&self, id: String)-> Result<(), Box<dyn Error>> {
+        match self {
+            #[cfg(feature = "bluetooth-test")]
+            BluetoothAdapter::Mock(inner) => Ok(inner.set_id(id)),
+            _ => Err(Box::from("Error! Test functions are not supported on real devices!")),
         }
-        Ok(None)
     }
 
-    fn create_mock_device(&self, device: String) -> Result<BluetoothDevice, Box<Error>> {
-        Ok(BluetoothDevice::Mock(FakeBluetoothDevice::new_empty(self.0.clone(), device)))
-        
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_address(&self, address: String) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_address, address)
     }
 
-    fn get_address(&self) -> Result<String, Box<Error>> {
-       self.0.get_address()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_name(&self, name: String) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_name, name)
     }
 
-    fn set_address(&self, address: String) -> Result<(), Box<Error>> {
-        self.0.set_address(address)
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_alias(&self, alias: String) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_alias, alias)
     }
 
-    fn get_name(&self) -> Result<String, Box<Error>> {
-       self.0.get_name()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_class(&self, class: u32) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_class, class)
     }
 
-    fn set_name(&self, name: String) -> Result<(), Box<Error>> {
-       self.0.set_name(name)
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_powered(&self, powered: bool) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_powered, powered)
     }
 
-    fn get_alias(&self) -> Result<String, Box<Error>> {
-       self.0.get_alias()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn is_present(&self) -> Result<bool, Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, is_present)
     }
 
-    fn set_alias(&self, alias: String) -> Result<(), Box<Error>> {
-        self.0.set_alias(alias)
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_present(&self, present: bool) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_present, present)
     }
 
-    fn get_class(&self) -> Result<u32, Box<Error>> {
-        self.0.get_class()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_discoverable(&self, discoverable: bool) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_discoverable, discoverable)
     }
 
-    fn set_class(&self, class: u32) -> Result<(), Box<Error>> {
-        self.0.set_class(class)
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_pairable(&self, pairable: bool) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_pairable, pairable)
     }
 
-    fn is_powered(&self) -> Result<bool, Box<Error>> {
-       self.0.is_powered()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_pairable_timeout(&self, timeout: u32) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_pairable_timeout, timeout)
     }
 
-    fn set_powered(&self, powered: bool) -> Result<(), Box<Error>> {
-        self.0.set_powered(powered)
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_can_start_discovery(&self, can_start_discovery: bool) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_can_start_discovery, can_start_discovery)
     }
 
-    fn is_present(&self) -> Result<bool, Box<Error>> {
-        self.0.is_present()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_discoverable_timeout(&self, timeout: u32) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_discoverable_timeout, timeout)
     }
 
-    fn set_present(&self, present: bool) -> Result<(), Box<Error>> {
-        self.0.set_present(present)
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_discovering(&self, discovering: bool) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_discovering, discovering)
     }
 
-    fn is_discoverable(&self) -> Result<bool, Box<Error>> {
-        self.0.is_discoverable()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_can_stop_discovery(&self, can_stop_discovery: bool) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_can_stop_discovery, can_stop_discovery)
     }
 
-    
-    fn set_discoverable(&self, discoverable: bool) -> Result<(), Box<Error>> {
-       self.0.set_discoverable(discoverable)
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_uuids, uuids)
     }
 
-    fn is_pairable(&self) -> Result<bool, Box<Error>> {
-        self.0.is_pairable()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_modalias(&self, modalias: String) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_modalias, modalias)
     }
 
-    fn set_pairable(&self, pairable: bool) -> Result<(), Box<Error>> {
-        self.0.set_pairable(pairable)
+    #[cfg(feature = "bluetooth-test")]
+    pub fn get_ad_datas(&self) -> Result<Vec<String>, Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, get_ad_datas)
     }
 
-    fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
-        self.0.get_pairable_timeout()
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_ad_datas(&self, ad_datas: Vec<String>) -> Result<(), Box<dyn Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_ad_datas, ad_datas)
     }
-
-    fn set_pairable_timeout(&self, timeout: u32) -> Result<(), Box<Error>> {
-        self.0.set_pairable_timeout(timeout)
-    }
-
-    fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
-        self.0.get_discoverable_timeout()
-    }
-
-    fn set_discoverable_timeout(&self, timeout: u32) -> Result<(), Box<Error>> {
-        self.0.set_discoverable_timeout(timeout)
-    }
-
-    fn is_discovering(&self) -> Result<bool, Box<Error>> {
-        self.0.is_discovering()
-    }
-
-    fn set_discovering(&self, discovering: bool) -> Result<(), Box<Error>> {
-        self.0.set_discovering(discovering)
-    }
-
-    fn set_can_start_discovery(&self, can_start_discovery: bool) -> Result<(), Box<Error>> {
-        self.0.set_can_start_discovery(can_start_discovery)
-    }
-
-    fn set_can_stop_discovery(&self, can_stop_discovery: bool) -> Result<(), Box<Error>> {
-        self.0.set_can_stop_discovery(can_stop_discovery)
-    }
-
-    fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let test_session = try!(FakeBluetoothDiscoverySession::create_session(self.0.clone()));
-        Ok(BluetoothDiscoverySession::Mock(Arc::new(test_session)))   
-
-    }
-
-    fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-       self.0.get_uuids()
-    }
-
-    fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>> {
-        self.0.set_uuids(uuids)
-    }
-
-    fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        self.0.get_vendor_id_source()
-    }
-
-    fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_vendor_id()
-    }
-
-    fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_product_id()
-    }
-
-    fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        self.0.get_device_id()
-    }
-
-    fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        self.0.get_modalias()
-    }
-
-    fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>> {
-        self.0.set_modalias(modalias)
-    }
-
-    fn get_ad_datas(&self) -> Result<Vec<String>, Box<Error>> {
-        self.0.get_ad_datas()
-    }
-
-    fn set_ad_datas(&self, ad_datas: Vec<String>) -> Result<(), Box<Error>> {
-        self.0.set_ad_datas(ad_datas)
-    }
-
 }

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -2,18 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
-use blurz::bluetooth_adapter::BluetoothAdapter as BluetoothAdapterBluez;
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
-use blurdroid::bluetooth_adapter::Adapter as BluetoothAdapterAndroid;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
-use blurmac::BluetoothAdapter as BluetoothAdapterMac;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-              all(target_os = "android", feature = "bluetooth"),
-              all(target_os = "macos", feature = "bluetooth"))))]
-use empty::EmptyAdapter as BluetoothAdapterEmpty;
-#[cfg(feature = "bluetooth-test")]
-use blurmock::fake_adapter::FakeBluetoothAdapter;
+pub use super::adapter::BluetoothAdapter;
 
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_device::BluetoothDevice as BluetoothDeviceBluez;
@@ -24,7 +13,7 @@ use blurmac::BluetoothDevice as BluetoothDeviceMac;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
-use empty::BluetoothDevice as BluetoothDeviceEmpty;
+use super::empty::BluetoothDevice as BluetoothDeviceEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_device::FakeBluetoothDevice;
 
@@ -37,7 +26,7 @@ use blurmac::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicMac;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
-use empty::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicEmpty;
+use super::empty::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_characteristic::FakeBluetoothGATTCharacteristic;
 
@@ -50,7 +39,7 @@ use blurmac::BluetoothGATTDescriptor as BluetoothGATTDescriptorMac;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
-use empty::BluetoothGATTDescriptor as BluetoothGATTDescriptorEmpty;
+use super::empty::BluetoothGATTDescriptor as BluetoothGATTDescriptorEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_descriptor::FakeBluetoothGATTDescriptor;
 
@@ -63,7 +52,7 @@ use blurmac::BluetoothGATTService as BluetoothGATTServiceMac;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
-use empty::BluetoothGATTService as BluetoothGATTServiceEmpty;
+use super::empty::BluetoothGATTService as BluetoothGATTServiceEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_service::FakeBluetoothGATTService;
 
@@ -76,16 +65,18 @@ use blurmac::BluetoothDiscoverySession as BluetoothDiscoverySessionMac;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
-use empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
+use super::empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_discovery_session::FakeBluetoothDiscoverySession;
+
+use super::macros::get_inner_and_call;
+#[cfg(feature = "bluetooth-test")]
+use super::macros::get_inner_and_call_test_func;
 
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::error::Error;
 
-#[cfg(feature = "bluetooth-test")]
-const NOT_SUPPORTED_ON_REAL_ERROR: &'static str = "Error! Test functions are not supported on real devices!";
 #[cfg(feature = "bluetooth-test")]
 const NOT_SUPPORTED_ON_MOCK_ERROR: &'static str = "Error! The first parameter must be a mock structure!";
 
@@ -170,102 +161,12 @@ pub enum BluetoothGATTDescriptor {
     Mock(Arc<FakeBluetoothGATTDescriptor>),
 }
 
-macro_rules! get_inner_and_call(
-    ($enum_value: expr, $enum_type: ident, $function_name: ident) => {
-        match $enum_value {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-            &$enum_type::Bluez(ref bluez) => bluez.$function_name(),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
-            &$enum_type::Android(ref android) => android.$function_name(),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
-            &$enum_type::Mac(ref mac) => mac.$function_name(),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-                          all(target_os = "android", feature = "bluetooth"),
-                          all(target_os = "macos", feature = "bluetooth"))))]
-            &$enum_type::Empty(ref empty) => empty.$function_name(),
-            #[cfg(feature = "bluetooth-test")]
-            &$enum_type::Mock(ref fake) => fake.$function_name(),
-        }
-    };
-
-    (@with_bluez_offset, $enum_value: expr, $enum_type: ident, $function_name: ident) => {
-        match $enum_value {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-            &$enum_type::Bluez(ref bluez) => bluez.$function_name(None),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
-            &$enum_type::Android(ref android) => android.$function_name(),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
-            &$enum_type::Mac(ref mac) => mac.$function_name(),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-                          all(target_os = "android", feature = "bluetooth"),
-                          all(target_os = "macos", feature = "bluetooth"))))]
-            &$enum_type::Empty(ref empty) => empty.$function_name(),
-            #[cfg(feature = "bluetooth-test")]
-            &$enum_type::Mock(ref fake) => fake.$function_name(),
-        }
-    };
-
-    ($enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
-        match $enum_value {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-            &$enum_type::Bluez(ref bluez) => bluez.$function_name($value),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
-            &$enum_type::Android(ref android) => android.$function_name($value),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
-            &$enum_type::Mac(ref mac) => mac.$function_name($value),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-                          all(target_os = "android", feature = "bluetooth"),
-                          all(target_os = "macos", feature = "bluetooth"))))]
-            &$enum_type::Empty(ref empty) => empty.$function_name($value),
-            #[cfg(feature = "bluetooth-test")]
-            &$enum_type::Mock(ref fake) => fake.$function_name($value),
-        }
-    };
-
-    (@with_bluez_offset, $enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
-        match $enum_value {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-            &$enum_type::Bluez(ref bluez) => bluez.$function_name($value, None),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
-            &$enum_type::Android(ref android) => android.$function_name($value),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
-            &$enum_type::Mac(ref mac) => mac.$function_name($value),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-                          all(target_os = "android", feature = "bluetooth"),
-                          all(target_os = "macos", feature = "bluetooth"))))]
-            &$enum_type::Empty(ref empty) => empty.$function_name($value),
-            #[cfg(feature = "bluetooth-test")]
-            &$enum_type::Mock(ref fake) => fake.$function_name($value),
-        }
-    };
-);
-
-#[cfg(feature = "bluetooth-test")]
-macro_rules! get_inner_and_call_test_func {
-    ($enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
-        match $enum_value {
-            &$enum_type::Mock(ref fake) => fake.$function_name($value),
-            _ => Err(Box::from(NOT_SUPPORTED_ON_REAL_ERROR)),
-        }
-    };
-
-    ($enum_value: expr, $enum_type: ident, $function_name: ident) => {
-        match $enum_value {
-            &$enum_type::Mock(ref fake) => fake.$function_name(),
-            _ => Err(Box::from(NOT_SUPPORTED_ON_REAL_ERROR)),
-        }
-    };
-}
-
-
-
 impl BluetoothDiscoverySession {
-
-    pub fn start_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn start_discovery(&self) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDiscoverySession, start_discovery)
     }
 
-    pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn stop_discovery(&self) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDiscoverySession, stop_discovery)
     }
 }
@@ -284,211 +185,211 @@ impl BluetoothDevice {
         }
     }
 
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_address)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_address(&self, address: String) -> Result<(), Box<Error>> {
+    pub fn set_address(&self, address: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_address, address)
     }
 
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_name)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_name(&self, name: Option<String>) -> Result<(), Box<Error>> {
+    pub fn set_name(&self, name: Option<String>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_name, name)
     }
 
-    pub fn get_icon(&self) -> Result<String, Box<Error>> {
+    pub fn get_icon(&self) -> Result<String, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_icon)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_icon(&self, icon: String) -> Result<(), Box<Error>> {
+    pub fn set_icon(&self, icon: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_icon, icon)
     }
 
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_class)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_class(&self, class: u32) -> Result<(), Box<Error>> {
+    pub fn set_class(&self, class: u32) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_class, class)
     }
 
-    pub fn get_appearance(&self) -> Result<u16, Box<Error>> {
+    pub fn get_appearance(&self) -> Result<u16, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_appearance)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_appearance(&self, appearance: u16) -> Result<(), Box<Error>> {
+    pub fn set_appearance(&self, appearance: u16) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_appearance, Some(appearance))
     }
 
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_uuids)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>> {
+    pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_uuids, uuids)
     }
 
-    pub fn is_paired(&self) -> Result<bool, Box<Error>> {
+    pub fn is_paired(&self) -> Result<bool, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, is_paired)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_paired(&self, paired: bool) -> Result<(), Box<Error>> {
+    pub fn set_paired(&self, paired: bool) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_paired, paired)
     }
 
-    pub fn is_connected(&self) -> Result<bool, Box<Error>> {
+    pub fn is_connected(&self) -> Result<bool, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, is_connected)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_connected(&self, connected: bool) -> Result<(), Box<Error>> {
+    pub fn set_connected(&self, connected: bool) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_connected, connected)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn is_connectable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_connectable(&self) -> Result<bool, Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, is_connectable)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_connectable(&self, connectable: bool) -> Result<(), Box<Error>> {
+    pub fn set_connectable(&self, connectable: bool) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_connectable, connectable)
     }
 
-    pub fn is_trusted(&self) -> Result<bool, Box<Error>> {
+    pub fn is_trusted(&self) -> Result<bool, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, is_trusted)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_trusted(&self, trusted: bool) -> Result<(), Box<Error>> {
+    pub fn set_trusted(&self, trusted: bool) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_trusted, trusted)
     }
 
-    pub fn is_blocked(&self) -> Result<bool, Box<Error>> {
+    pub fn is_blocked(&self) -> Result<bool, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, is_blocked)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_blocked(&self, blocked: bool) -> Result<(), Box<Error>> {
+    pub fn set_blocked(&self, blocked: bool) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_blocked, blocked)
     }
 
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_alias)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_alias(&self, alias: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, alias: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_alias, alias)
     }
 
-    pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
+    pub fn is_legacy_pairing(&self) -> Result<bool, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, is_legacy_pairing)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_legacy_pairing(&self, legacy_pairing: bool) -> Result<(), Box<Error>> {
+    pub fn set_legacy_pairing(&self, legacy_pairing: bool) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_legacy_pairing, legacy_pairing)
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_vendor_id_source)
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_vendor_id)
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_product_id)
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_device_id)
     }
 
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_modalias)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>> {
+    pub fn set_modalias(&self, modalias: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_modalias, modalias)
     }
 
-    pub fn get_rssi(&self) -> Result<i16, Box<Error>> {
+    pub fn get_rssi(&self) -> Result<i16, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_rssi)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_rssi(&self, rssi: i16) -> Result<(), Box<Error>> {
+    pub fn set_rssi(&self, rssi: i16) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_rssi, Some(rssi))
     }
 
-    pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
+    pub fn get_tx_power(&self) -> Result<i16, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_tx_power)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_tx_power(&self, tx_power: i16) -> Result<(), Box<Error>> {
+    pub fn set_tx_power(&self, tx_power: i16) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_tx_power, Some(tx_power))
     }
 
-    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<Error>> {
+    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_manufacturer_data)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_manufacturer_data(&self, manufacturer_data: HashMap<u16, Vec<u8>>) -> Result<(), Box<Error>> {
+    pub fn set_manufacturer_data(&self, manufacturer_data: HashMap<u16, Vec<u8>>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_manufacturer_data, Some(manufacturer_data))
     }
 
-    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<Error>> {
+    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_service_data)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_service_data(&self, service_data: HashMap<String, Vec<u8>>) -> Result<(), Box<Error>> {
+    pub fn set_service_data(&self, service_data: HashMap<String, Vec<u8>>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_service_data, Some(service_data))
     }
 
-    pub fn get_gatt_services(&self) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
-        let services = try!(get_inner_and_call!(self, BluetoothDevice, get_gatt_services));
+    pub fn get_gatt_services(&self) -> Result<Vec<BluetoothGATTService>, Box<dyn Error>> {
+        let services = get_inner_and_call!(self, BluetoothDevice, get_gatt_services)?;
         Ok(services.into_iter().map(|service| BluetoothGATTService::create_service(self.clone(), service)).collect())
     }
 
-    pub fn connect(&self) -> Result<(), Box<Error>> {
+    pub fn connect(&self) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, connect)
     }
 
-    pub fn disconnect(&self) -> Result<(), Box<Error>> {
+    pub fn disconnect(&self) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, disconnect)
     }
 
-    pub fn connect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn connect_profile(&self, uuid: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, connect_profile, uuid)
     }
 
-    pub fn disconnect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn disconnect_profile(&self, uuid: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, disconnect_profile, uuid)
     }
 
-    pub fn pair(&self) -> Result<(), Box<Error>> {
+    pub fn pair(&self) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, pair)
     }
 
-    pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
+    pub fn cancel_pairing(&self) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothDevice, cancel_pairing)
     }
 }
@@ -522,13 +423,13 @@ impl BluetoothGATTService {
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn create_mock_service(device: BluetoothDevice, service: String) -> Result<BluetoothGATTService, Box<Error>> {
+    pub fn create_mock_service(device: BluetoothDevice, service: String) -> Result<BluetoothGATTService, Box<dyn Error>> {
         match device {
             BluetoothDevice::Mock(fake_device) => {
                 Ok(BluetoothGATTService::Mock(FakeBluetoothGATTService::new_empty(fake_device, service)))
             },
             _ => {
-                Err(Box::from(NOT_SUPPORTED_ON_MOCK_ERROR))
+                Err(Box::from("Error! The first parameter must be a mock structure!"))
             },
         }
     }
@@ -545,31 +446,31 @@ impl BluetoothGATTService {
         }
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTService, get_uuid)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn set_uuid(&self, uuid: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTService, set_uuid, uuid)
     }
 
-    pub fn is_primary(&self) -> Result<bool, Box<Error>> {
+    pub fn is_primary(&self) -> Result<bool, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTService, is_primary)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_primary(&self, primary: bool) -> Result<(), Box<Error>> {
+    pub fn set_primary(&self, primary: bool) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTService, set_is_primary, primary)
     }
 
-    pub fn get_includes(&self, device: BluetoothDevice) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
-        let services = try!(get_inner_and_call!(self, BluetoothGATTService, get_includes));
+    pub fn get_includes(&self, device: BluetoothDevice) -> Result<Vec<BluetoothGATTService>, Box<dyn Error>> {
+        let services = get_inner_and_call!(self, BluetoothGATTService, get_includes)?;
         Ok(services.into_iter().map(|service| BluetoothGATTService::create_service(device.clone(), service)).collect())
     }
 
-    pub fn get_gatt_characteristics(&self) -> Result<Vec<BluetoothGATTCharacteristic>, Box<Error>> {
-        let characteristics = try!(get_inner_and_call!(self, BluetoothGATTService, get_gatt_characteristics));
+    pub fn get_gatt_characteristics(&self) -> Result<Vec<BluetoothGATTCharacteristic>, Box<dyn Error>> {
+        let characteristics = get_inner_and_call!(self, BluetoothGATTService, get_gatt_characteristics)?;
         Ok(characteristics.into_iter()
                           .map(|characteristic|
                               BluetoothGATTCharacteristic::create_characteristic(self.clone(), characteristic))
@@ -610,14 +511,14 @@ impl BluetoothGATTCharacteristic {
     #[cfg(feature = "bluetooth-test")]
     pub fn create_mock_characteristic(service: BluetoothGATTService,
                                       characteristic: String)
-                                      -> Result<BluetoothGATTCharacteristic, Box<Error>> {
+                                      -> Result<BluetoothGATTCharacteristic, Box<dyn Error>> {
         match service {
             BluetoothGATTService::Mock(fake_service) => {
                 Ok(BluetoothGATTCharacteristic::Mock(
                     FakeBluetoothGATTCharacteristic::new_empty(fake_service, characteristic)))
             },
             _ => {
-                Err(Box::from(NOT_SUPPORTED_ON_MOCK_ERROR))
+                Err(Box::from("Error! The first parameter must be a mock structure!"))
             },
         }
     }
@@ -634,62 +535,62 @@ impl BluetoothGATTCharacteristic {
         }
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, get_uuid)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn set_uuid(&self, uuid: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_uuid, uuid)
     }
 
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, get_value)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_value(&self, value: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn set_value(&self, value: Vec<u8>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_value, Some(value))
     }
 
-    pub fn is_notifying(&self) -> Result<bool, Box<Error>> {
+    pub fn is_notifying(&self) -> Result<bool, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, is_notifying)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_notifying(&self, notifying: bool) -> Result<(), Box<Error>> {
+    pub fn set_notifying(&self, notifying: bool) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_notifying, notifying)
     }
 
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, get_flags)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_flags(&self, flags: Vec<String>) -> Result<(), Box<Error>> {
+    pub fn set_flags(&self, flags: Vec<String>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_flags, flags)
     }
 
-    pub fn get_gatt_descriptors(&self) -> Result<Vec<BluetoothGATTDescriptor>, Box<Error>> {
-        let descriptors = try!(get_inner_and_call!(self, BluetoothGATTCharacteristic, get_gatt_descriptors));
+    pub fn get_gatt_descriptors(&self) -> Result<Vec<BluetoothGATTDescriptor>, Box<dyn Error>> {
+        let descriptors = get_inner_and_call!(self, BluetoothGATTCharacteristic, get_gatt_descriptors)?;
         Ok(descriptors.into_iter()
                       .map(|descriptor| BluetoothGATTDescriptor::create_descriptor(self.clone(), descriptor))
                       .collect())
     }
 
-    pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         get_inner_and_call!(@with_bluez_offset, self, BluetoothGATTCharacteristic, read_value)
     }
 
-    pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(@with_bluez_offset, self, BluetoothGATTCharacteristic, write_value, values)
     }
 
-    pub fn start_notify(&self) -> Result<(), Box<Error>> {
+    pub fn start_notify(&self) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, start_notify)
     }
 
-    pub fn stop_notify(&self) -> Result<(), Box<Error>> {
+    pub fn stop_notify(&self) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, stop_notify)
     }
 }
@@ -726,7 +627,7 @@ impl BluetoothGATTDescriptor {
     #[cfg(feature = "bluetooth-test")]
     pub fn create_mock_descriptor(characteristic: BluetoothGATTCharacteristic,
                                   descriptor: String)
-                                  -> Result<BluetoothGATTDescriptor, Box<Error>> {
+                                  -> Result<BluetoothGATTDescriptor, Box<dyn Error>> {
         match characteristic {
             BluetoothGATTCharacteristic::Mock(fake_characteristic) => {
                 Ok(BluetoothGATTDescriptor::Mock(
@@ -750,38 +651,38 @@ impl BluetoothGATTDescriptor {
         }
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTDescriptor, get_uuid)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
+    pub fn set_uuid(&self, uuid: String) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTDescriptor, set_uuid, uuid)
     }
 
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTDescriptor, get_value)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_value(&self, value: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn set_value(&self, value: Vec<u8>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTDescriptor, set_value, Some(value))
     }
 
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
         get_inner_and_call!(self, BluetoothGATTDescriptor, get_flags)
     }
 
     #[cfg(feature = "bluetooth-test")]
-    pub fn set_flags(&self, flags: Vec<String>) -> Result<(), Box<Error>> {
+    pub fn set_flags(&self, flags: Vec<String>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTDescriptor, set_flags, flags)
     }
 
-    pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         get_inner_and_call!(@with_bluez_offset, self, BluetoothGATTDescriptor, read_value)
     }
 
-    pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<dyn Error>> {
         get_inner_and_call!(@with_bluez_offset, self, BluetoothGATTDescriptor, write_value, values)
     }
 }

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -12,7 +12,7 @@ const NOT_SUPPORTED_ERROR: &'static str = "Error! Not supported platform!";
 pub struct EmptyAdapter { }
 
 impl EmptyAdapter {
-    pub fn init() -> Result<EmptyAdapter, Box<Error>> {
+    pub fn init() -> Result<EmptyAdapter, Box<dyn Error>> {
         Ok(EmptyAdapter::new())
     }
 
@@ -24,95 +24,95 @@ impl EmptyAdapter {
         String::new()
     }
 
-    pub fn get_device_list(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_device_list(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_alias(&self, _value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, _value: String) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_powered(&self) -> Result<bool, Box<Error>> {
+    pub fn is_powered(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_powered(&self, _value: bool) -> Result<(), Box<Error>> {
+    pub fn set_powered(&self, _value: bool) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_discoverable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_discoverable(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_discoverable(&self, _value: bool) -> Result<(), Box<Error>> {
+    pub fn set_discoverable(&self, _value: bool) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_pairable(&self) -> Result<bool, Box<Error>> {
+    pub fn is_pairable(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_pairable(&self, _value: bool) -> Result<(), Box<Error>> {
+    pub fn set_pairable(&self, _value: bool) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
+    pub fn get_pairable_timeout(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_pairable_timeout(&self, _value: u32) -> Result<(), Box<Error>> {
+    pub fn set_pairable_timeout(&self, _value: u32) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
+    pub fn get_discoverable_timeout(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_discoverable_timeout(&self, _value: u32) -> Result<(), Box<Error>> {
+    pub fn set_discoverable_timeout(&self, _value: u32) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_discovering(&self) -> Result<bool, Box<Error>> {
+    pub fn is_discovering(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 }
@@ -121,15 +121,15 @@ impl EmptyAdapter {
 pub struct BluetoothDiscoverySession { }
 
 impl BluetoothDiscoverySession {
-    pub fn create_session(_adapter: Arc<EmptyAdapter>) -> Result<BluetoothDiscoverySession, Box<Error>> {
+    pub fn create_session(_adapter: Arc<EmptyAdapter>) -> Result<BluetoothDiscoverySession, Box<dyn Error>> {
         Ok(BluetoothDiscoverySession{ })
     }
 
-    pub fn start_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn start_discovery(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
+    pub fn stop_discovery(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 }
@@ -146,119 +146,119 @@ impl BluetoothDevice {
         String::new()
     }
 
-    pub fn get_address(&self) -> Result<String, Box<Error>> {
+    pub fn get_address(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_name(&self) -> Result<String, Box<Error>> {
+    pub fn get_name(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_icon(&self) -> Result<String, Box<Error>> {
+    pub fn get_icon(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_class(&self) -> Result<u32, Box<Error>> {
+    pub fn get_class(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_appearance(&self) -> Result<u16, Box<Error>> {
+    pub fn get_appearance(&self) -> Result<u16, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_uuids(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_paired(&self) -> Result<bool, Box<Error>> {
+    pub fn is_paired(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_connected(&self) -> Result<bool, Box<Error>> {
+    pub fn is_connected(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_trusted(&self) -> Result<bool, Box<Error>> {
+    pub fn is_trusted(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_blocked(&self) -> Result<bool, Box<Error>> {
+    pub fn is_blocked(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_alias(&self) -> Result<String, Box<Error>> {
+    pub fn get_alias(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn set_alias(&self, _value: String) -> Result<(), Box<Error>> {
+    pub fn set_alias(&self, _value: String) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
+    pub fn is_legacy_pairing(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
+    pub fn get_vendor_id_source(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_vendor_id(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_product_id(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
+    pub fn get_device_id(&self) -> Result<u32, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
+    pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_rssi(&self) -> Result<i16, Box<Error>> {
+    pub fn get_rssi(&self) -> Result<i16, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
+    pub fn get_tx_power(&self) -> Result<i16, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<Error>> {
+    pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<Error>> {
+    pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn connect(&self) -> Result<(), Box<Error>> {
+    pub fn connect(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn disconnect(&self) -> Result<(), Box<Error>> {
+    pub fn disconnect(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn connect_profile(&self, _uuid: String) -> Result<(), Box<Error>> {
+    pub fn connect_profile(&self, _uuid: String) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn disconnect_profile(&self, _uuid: String) -> Result<(), Box<Error>> {
+    pub fn disconnect_profile(&self, _uuid: String) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn pair(&self) -> Result<(), Box<Error>> {
+    pub fn pair(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
+    pub fn cancel_pairing(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 }
@@ -275,19 +275,19 @@ impl BluetoothGATTService {
         String::new()
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_primary(&self) -> Result<bool, Box<Error>> {
+    pub fn is_primary(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_includes(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_includes(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_characteristics(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 }
@@ -304,39 +304,39 @@ impl BluetoothGATTCharacteristic {
         String::new()
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn is_notifying(&self) -> Result<bool, Box<Error>> {
+    pub fn is_notifying(&self) -> Result<bool, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_gatt_descriptors(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn write_value(&self, _values: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, _values: Vec<u8>) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn start_notify(&self) -> Result<(), Box<Error>> {
+    pub fn start_notify(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn stop_notify(&self) -> Result<(), Box<Error>> {
+    pub fn stop_notify(&self) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 }
@@ -353,23 +353,23 @@ impl BluetoothGATTDescriptor {
         String::new()
     }
 
-    pub fn get_uuid(&self) -> Result<String, Box<Error>> {
+    pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn get_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
+    pub fn get_flags(&self) -> Result<Vec<String>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
+    pub fn read_value(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
-    pub fn write_value(&self, _values: Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_value(&self, _values: Vec<u8>) -> Result<(), Box<dyn Error>> {
         Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  *  * License, v. 2.0. If a copy of the MPL was not distributed with this
  *   * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 extern crate blurz;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
@@ -16,3 +16,4 @@ pub mod bluetooth;
               all(target_os = "android", feature = "bluetooth"),
               all(target_os = "macos", feature = "bluetooth"))))]
 mod empty;
+mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ *  * License, v. 2.0. If a copy of the MPL was not distributed with this
+ *   * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+macro_rules! get_inner_and_call(
+    ($enum_value: expr, $enum_type: ident, $function_name: ident) => {
+        match $enum_value {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &$enum_type::Bluez(ref bluez) => bluez.$function_name(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &$enum_type::Android(ref android) => android.$function_name(),
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            &$enum_type::Mac(ref mac) => mac.$function_name(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
+            &$enum_type::Empty(ref empty) => empty.$function_name(),
+            #[cfg(feature = "bluetooth-test")]
+            &$enum_type::Mock(ref fake) => fake.$function_name(),
+        }
+    };
+
+    (@with_bluez_offset, $enum_value: expr, $enum_type: ident, $function_name: ident) => {
+        match $enum_value {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &$enum_type::Bluez(ref bluez) => bluez.$function_name(None),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &$enum_type::Android(ref android) => android.$function_name(),
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            &$enum_type::Mac(ref mac) => mac.$function_name(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
+            &$enum_type::Empty(ref empty) => empty.$function_name(),
+            #[cfg(feature = "bluetooth-test")]
+            &$enum_type::Mock(ref fake) => fake.$function_name(),
+        }
+    };
+
+    ($enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
+        match $enum_value {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &$enum_type::Bluez(ref bluez) => bluez.$function_name($value),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &$enum_type::Android(ref android) => android.$function_name($value),
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            &$enum_type::Mac(ref mac) => mac.$function_name($value),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
+            &$enum_type::Empty(ref empty) => empty.$function_name($value),
+            #[cfg(feature = "bluetooth-test")]
+            &$enum_type::Mock(ref fake) => fake.$function_name($value),
+        }
+    };
+
+    (@with_bluez_offset, $enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
+        match $enum_value {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &$enum_type::Bluez(ref bluez) => bluez.$function_name($value, None),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &$enum_type::Android(ref android) => android.$function_name($value),
+            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            &$enum_type::Mac(ref mac) => mac.$function_name($value),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
+                          all(target_os = "android", feature = "bluetooth"),
+                          all(target_os = "macos", feature = "bluetooth"))))]
+            &$enum_type::Empty(ref empty) => empty.$function_name($value),
+            #[cfg(feature = "bluetooth-test")]
+            &$enum_type::Mock(ref fake) => fake.$function_name($value),
+        }
+    };
+);
+
+#[cfg(feature = "bluetooth-test")]
+macro_rules! get_inner_and_call_test_func {
+    ($enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
+        match $enum_value {
+            &$enum_type::Mock(ref fake) => fake.$function_name($value),
+            _ => Err(Box::from("Error! Test functions are not supported on real devices!")),
+        }
+    };
+
+    ($enum_value: expr, $enum_type: ident, $function_name: ident) => {
+        match $enum_value {
+            &$enum_type::Mock(ref fake) => fake.$function_name(),
+            _ => Err(Box::from("Error! Test functions are not supported on real devices!")),
+        }
+    };
+}
+
+pub(crate) use get_inner_and_call;
+#[cfg(feature = "bluetooth-test")]
+pub(crate) use get_inner_and_call_test_func;


### PR DESCRIPTION
In addition to fixing all of the compilation errors for the upgrade to
Rust 2018, this change also reverts the conversion of BluetoothAdapter
into a trait. This was never integrated into Servo.

In newer versions of Rust, it seems harder to put a `dyn` trait
implementation into an Option since it isn't sized. In addition, the
trait-based implementation leads to a lot of duplicated code. There is
probably a better way to hide the implementation details of the
bluetooth crate than using traits here.

In fact, a good long-term approach is probably to remove this crate
entirely and switch to using a platform-independent bluetooth
implementation which exists for Rust now. In the meantime, this will
allow Servo to use the newest version of this crate, which is doesn't
yet.
